### PR TITLE
Fix Storybook base path for GitHub Pages

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,5 +4,14 @@ const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: ['@storybook/addon-docs'],
   framework: 'storybook-react-rsbuild',
+  rsbuildFinal: (config) => {
+    if (process.env.GITHUB_ACTIONS) {
+      config.output = {
+        ...config.output,
+        assetPrefix: '/wordles-with-friends-client-web/',
+      };
+    }
+    return config;
+  },
 };
 export default config;


### PR DESCRIPTION
## Summary
- Sets `assetPrefix` to `/wordles-with-friends-client-web/` when building in GitHub Actions
- Fixes the infinite spinner issue where assets failed to load from the subpath

## Test plan
- [ ] Merge and wait for deploy workflow to complete
- [ ] Visit https://hannahscovill.github.io/wordles-with-friends-client-web/
- [ ] Verify Storybook loads and displays stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)