### PR TITLE
Fix fonts by adding global.scss with Google Fonts

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,0 @@
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import type { Preview } from 'storybook-react-rsbuild';
 import '../src/tokens.module.scss';
+import '../src/global.scss';
 
 const preview: Preview = {
   parameters: {

--- a/src/global.scss
+++ b/src/global.scss
@@ -1,0 +1,13 @@
+// Global styles - imported by both the app and Storybook
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+body {
+  margin: 0;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+}
+
+#root {
+  width: 100%;
+  min-height: 100vh;
+}


### PR DESCRIPTION
## Summary
- Adds `global.scss` with Inter font loaded via Google Fonts CSS import
- Imports `global.scss` in `preview.ts` so all stories use the correct font
- Removes unused `preview-head.html` (wasn't being picked up by Storybook)

## Root cause
The deployed Storybook was missing:
1. The `global.scss` file (wasn't committed to main)
2. The Google Fonts import for Inter

Local Storybook worked because Inter was installed system-wide.

## Test plan
- [ ] Merge and wait for deploy
- [ ] Verify AppHeader shows Inter font (not Times serif)
- [ ] Compare with local Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)