### PR TITLE
Fix font loading by injecting link in preview.ts

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -2,6 +2,13 @@ import type { Preview } from 'storybook-react-rsbuild';
 import '../src/tokens.module.scss';
 import '../src/global.scss';
 
+// Load Google Fonts
+const fontLink = document.createElement('link');
+fontLink.href =
+  'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap';
+fontLink.rel = 'stylesheet';
+document.head.appendChild(fontLink);
+
 const preview: Preview = {
   parameters: {
     layout: 'centered',

--- a/src/global.scss
+++ b/src/global.scss
@@ -1,7 +1,5 @@
 // Global styles - imported by both the app and Storybook
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-
 body {
   margin: 0;
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;


### PR DESCRIPTION
## Summary
- Removes `@import url()` from global.scss (was breaking SCSS bundling)
- Adds Google Fonts link programmatically in preview.ts

## Root cause
The `@import url()` at the top of global.scss was causing rsbuild to not bundle the body styles. Moving the font loading to JavaScript ensures both the font link and body styles are applied.

## Test plan
- [ ] Merge and wait for deploy
- [ ] Verify AppHeader uses Inter font (not Times)

🤖 Generated with [Claude Code](https://claude.com/claude-code)