### PR TITLE
feat: Add server-side guess validation with toast notifications

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,6 @@
+# Production Configuration
+# Override PUBLIC_API_URL with your production API URL
+PUBLIC_AUTH0_DOMAIN=dev-g32naui5mvpwnsg7.us.auth0.com
+PUBLIC_AUTH0_CLIENT_ID=4AGUSKMPWgc4jMKUFIJzbS7GBY9IDZob
+PUBLIC_AUTH0_AUDIENCE=com.hannahscovill.scorekeeper
+PUBLIC_API_URL=https://api.yourproduction.com

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ storybook-static
 .env
 .playwright-mcp
 TEST_CREDENTIALS.txt
+zzLocalDev/

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -4,9 +4,13 @@ import './GameBoard.scss';
 
 const TOTAL_ROWS: number = 6;
 
+export interface GameBoardGuess extends GuessWordProps {
+  shake?: boolean;
+}
+
 export interface GameBoardProps {
   /** Array of up to 6 GuessWord configurations */
-  guesses: GuessWordProps[];
+  guesses: GameBoardGuess[];
 }
 
 export const GameBoard = ({ guesses }: GameBoardProps): ReactElement => {
@@ -14,7 +18,11 @@ export const GameBoard = ({ guesses }: GameBoardProps): ReactElement => {
     <div className="game-board">
       {Array.from({ length: TOTAL_ROWS }, (_, index) =>
         guesses[index] ? (
-          <GuessWord key={index} {...guesses[index]} />
+          <GuessWord
+            key={index}
+            boxes={guesses[index].boxes}
+            shake={guesses[index].shake}
+          />
         ) : (
           <GuessWordEmpty key={index} />
         ),

--- a/src/components/GuessWord.scss
+++ b/src/components/GuessWord.scss
@@ -2,4 +2,28 @@
   display: flex;
   flex-direction: row;
   gap: 4px;
+
+  &--shake {
+    animation: shake 0.5s ease-in-out;
+  }
+}
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  10%,
+  30%,
+  50%,
+  70%,
+  90% {
+    transform: translateX(-5px);
+  }
+  20%,
+  40%,
+  60%,
+  80% {
+    transform: translateX(5px);
+  }
 }

--- a/src/components/GuessWord.tsx
+++ b/src/components/GuessWord.tsx
@@ -11,11 +11,13 @@ export interface GuessWordProps {
     GuessLetterProps,
     GuessLetterProps,
   ];
+  /** Whether to show shake animation */
+  shake?: boolean;
 }
 
-export const GuessWord = ({ boxes }: GuessWordProps): ReactElement => {
+export const GuessWord = ({ boxes, shake }: GuessWordProps): ReactElement => {
   return (
-    <div className="guess-word">
+    <div className={`guess-word${shake ? ' guess-word--shake' : ''}`}>
       {boxes.map((boxProps, index) => (
         <GuessLetter key={index} {...boxProps} />
       ))}

--- a/src/components/Toast.scss
+++ b/src/components/Toast.scss
@@ -1,0 +1,42 @@
+.toast-container {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 16px;
+  overflow: hidden;
+  z-index: 1000;
+}
+
+.toast {
+  background: #fff;
+  color: #000;
+  padding: 12px 16px;
+  border: 4px solid #000;
+  font-size: 1rem;
+  font-weight: 600;
+  white-space: nowrap;
+  animation: toast-slide-up 0.2s ease-out forwards;
+
+  &--hiding {
+    animation: toast-slide-down 0.2s ease-in forwards;
+  }
+}
+
+@keyframes toast-slide-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes toast-slide-down {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(100%);
+  }
+}

--- a/src/components/Toast.stories.tsx
+++ b/src/components/Toast.stories.tsx
@@ -1,0 +1,135 @@
+import { useState, useCallback, type ReactElement } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Toast } from './Toast';
+
+const meta: Meta<typeof Toast> = {
+  title: 'Components/Toast',
+  component: Toast,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (): ReactElement => (
+    <div
+      style={{
+        background: '#e8e9de',
+        minHeight: '300px',
+        padding: '2rem',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <div style={{ position: 'relative' }}>
+        <div
+          style={{
+            width: '280px',
+            height: '150px',
+            background: '#ccc',
+            border: '2px solid #000',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontWeight: 600,
+          }}
+        >
+          Game Board
+        </div>
+        <Toast
+          message="Not in word list"
+          visible={true}
+          onHide={(): void => {}}
+          duration={999999}
+        />
+      </div>
+    </div>
+  ),
+};
+
+const InteractiveDemo = (): ReactElement => {
+  const [visible, setVisible] = useState<boolean>(false);
+
+  const showToast: () => void = useCallback((): void => {
+    setVisible(true);
+  }, []);
+
+  const hideToast: () => void = useCallback((): void => {
+    setVisible(false);
+  }, []);
+
+  return (
+    <div
+      style={{
+        background: '#e8e9de',
+        minHeight: '500px',
+        padding: '2rem',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: '2rem',
+      }}
+    >
+      <button
+        type="button"
+        onClick={showToast}
+        style={{
+          padding: '12px 16px',
+          border: '4px solid #000',
+          background: '#fff',
+          fontWeight: 600,
+          cursor: 'pointer',
+        }}
+      >
+        Submit Invalid Word
+      </button>
+      <div style={{ position: 'relative' }}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+          }}
+        >
+          {['ZZZZZ', '', '', '', '', ''].map((word, rowIndex) => (
+            <div key={rowIndex} style={{ display: 'flex', gap: '4px' }}>
+              {Array.from({ length: 5 }).map((_, colIndex) => (
+                <div
+                  key={colIndex}
+                  style={{
+                    width: '52px',
+                    height: '52px',
+                    border: '2px solid #3a3a3c',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: '2rem',
+                    fontWeight: 700,
+                    background: rowIndex === 0 ? '#3a3a3c' : '#121213',
+                    color: '#fff',
+                  }}
+                >
+                  {word[colIndex] ?? ''}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+        <Toast
+          message="Not in word list"
+          visible={visible}
+          onHide={hideToast}
+          duration={1500}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const Interactive: Story = {
+  render: (): ReactElement => <InteractiveDemo />,
+};

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,68 @@
+import {
+  useEffect,
+  useState,
+  useRef,
+  type ReactElement,
+  type MutableRefObject,
+} from 'react';
+import './Toast.scss';
+
+export interface ToastProps {
+  message: string;
+  visible: boolean;
+  onHide: () => void;
+  duration?: number;
+}
+
+export const Toast = ({
+  message,
+  visible,
+  onHide,
+  duration = 1500,
+}: ToastProps): ReactElement | null => {
+  const [isHiding, setIsHiding] = useState<boolean>(false);
+  const [shouldRender, setShouldRender] = useState<boolean>(false);
+  const hideTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null> =
+    useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (visible && !shouldRender) {
+      // Start showing - use setTimeout to avoid sync setState
+      const showTimer: ReturnType<typeof setTimeout> = setTimeout((): void => {
+        setShouldRender(true);
+        setIsHiding(false);
+      }, 0);
+      return (): void => clearTimeout(showTimer);
+    }
+
+    if (visible && shouldRender) {
+      // Schedule hide
+      hideTimerRef.current = setTimeout((): void => {
+        setIsHiding(true);
+        // Wait for animation to complete before calling onHide
+        setTimeout((): void => {
+          setShouldRender(false);
+          onHide();
+        }, 150);
+      }, duration);
+
+      return (): void => {
+        if (hideTimerRef.current) {
+          clearTimeout(hideTimerRef.current);
+        }
+      };
+    }
+
+    return undefined;
+  }, [visible, shouldRender, duration, onHide]);
+
+  if (!shouldRender) return null;
+
+  return (
+    <div className="toast-container">
+      <div className={`toast${isHiding ? ' toast--hiding' : ''}`} role="alert">
+        {message}
+      </div>
+    </div>
+  );
+};

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,5 +14,7 @@ declare global {
   interface ImportMetaEnv {
     readonly PUBLIC_AUTH0_DOMAIN: string;
     readonly PUBLIC_AUTH0_CLIENT_ID: string;
+    readonly PUBLIC_AUTH0_AUDIENCE?: string;
+    readonly PUBLIC_API_URL?: string;
   }
 }

--- a/src/hooks/useSubmitGuess.ts
+++ b/src/hooks/useSubmitGuess.ts
@@ -1,0 +1,47 @@
+import { useState, useCallback } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import { submitGuess as submitGuessApi, type GameState } from '../api/guess';
+
+interface UseSubmitGuessReturn {
+  submit: (guess: string) => Promise<GameState | null>;
+  isSubmitting: boolean;
+  error: Error | null;
+  clearError: () => void;
+}
+
+export function useSubmitGuess(puzzleDate: string): UseSubmitGuessReturn {
+  const { getAccessTokenSilently, isAuthenticated } = useAuth0();
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const submit: (guess: string) => Promise<GameState | null> = useCallback(
+    async (guess: string): Promise<GameState | null> => {
+      setIsSubmitting(true);
+      setError(null);
+
+      try {
+        const token: string | undefined = isAuthenticated
+          ? await getAccessTokenSilently()
+          : undefined;
+
+        return await submitGuessApi(
+          { puzzle_date_iso_day: puzzleDate, word_guessed: guess },
+          { token },
+        );
+      } catch (e: unknown) {
+        const err: Error = e instanceof Error ? e : new Error(String(e));
+        setError(err);
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [puzzleDate, isAuthenticated, getAccessTokenSilently],
+  );
+
+  const clearError: () => void = useCallback((): void => {
+    setError(null);
+  }, []);
+
+  return { submit, isSubmitting, error, clearError };
+}

--- a/src/pages/HomePage.scss
+++ b/src/pages/HomePage.scss
@@ -3,4 +3,8 @@
   flex-direction: column;
   align-items: center;
   gap: 32px;
+
+  &__game-container {
+    position: relative;
+  }
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,8 @@
-import type { ReactElement } from 'react';
+import { useState, useEffect, useCallback, type ReactElement } from 'react';
 import { GameBoard } from '../components/GameBoard';
 import { GameStatusModal } from '../components/GameStatusModal';
 import { Keyboard } from '../components/Keyboard';
+import { Toast } from '../components/Toast';
 import { useGame } from '../hooks/useGame';
 import './HomePage.scss';
 
@@ -11,11 +12,29 @@ export const HomePage = (): ReactElement => {
     keyStates,
     status,
     answer,
+    invalidWord,
     onKeyPress,
     onEnter,
     onBackspace,
     onNewGame,
   } = useGame();
+
+  const [showToast, setShowToast] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (invalidWord) {
+      // Use setTimeout to avoid synchronous setState in effect
+      const timer: ReturnType<typeof setTimeout> = setTimeout((): void => {
+        setShowToast(true);
+      }, 0);
+      return (): void => clearTimeout(timer);
+    }
+    return undefined;
+  }, [invalidWord]);
+
+  const hideToast: () => void = useCallback((): void => {
+    setShowToast(false);
+  }, []);
 
   return (
     <div className="home-page">
@@ -26,7 +45,14 @@ export const HomePage = (): ReactElement => {
           onPlayAgain={onNewGame}
         />
       )}
-      <GameBoard guesses={guesses} />
+      <div className="home-page__game-container">
+        <GameBoard guesses={guesses} />
+        <Toast
+          message="Not in word list"
+          visible={showToast}
+          onHide={hideToast}
+        />
+      </div>
       <Keyboard
         keyStates={keyStates}
         onKeyPress={onKeyPress}


### PR DESCRIPTION
## Summary
- Integrate POST `/guess` endpoint for server-side word validation
- Anonymous users get a session cookie, authenticated users send Bearer token
- Invalid words trigger a "Not in word list" toast that slides up from behind the game board
- Add shake animation on current guess row when word is rejected

## Changes
- **`src/api/guess.ts`**: New API module with session cookie handling for anonymous users
- **`src/components/Toast.tsx`**: Toast component with slide-up/down animation
- **`src/components/GuessWord.tsx`**: Added shake animation support
- **`src/hooks/useGame.ts`**: Integrated async API submission, removed local grading
- **`src/pages/HomePage.tsx`**: Added toast display and game container for positioning

## Test plan
- [ ] Submit an invalid word (e.g., "ZZZZZ") and verify toast appears
- [ ] Verify toast slides up from behind game board and drops back down
- [ ] Verify shake animation plays on invalid word submission
- [ ] Test as anonymous user (session cookie should be set)
- [ ] Test as authenticated user (Bearer token should be sent)

🤖 Generated with [Claude Code](https://claude.ai/code)