### PR TITLE
config: Set production API URL to scorekeeper ELB

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -3,4 +3,4 @@
 PUBLIC_AUTH0_DOMAIN=dev-g32naui5mvpwnsg7.us.auth0.com
 PUBLIC_AUTH0_CLIENT_ID=4AGUSKMPWgc4jMKUFIJzbS7GBY9IDZob
 PUBLIC_AUTH0_AUDIENCE=com.hannahscovill.scorekeeper
-PUBLIC_API_URL=https://api.yourproduction.com
+PUBLIC_API_URL=http://Scorek-Score-oP0DvEpQnuUI-244347713.us-west-2.elb.amazonaws.com


### PR DESCRIPTION
## Summary
- Configure production API URL to point to the scorekeeper ELB endpoint

## Changes
- **.env.production**: Set `PUBLIC_API_URL` to the scorekeeper ELB

## Test plan
- [x] Production build works with preview server
- [ ] Set GitHub secrets and merge to trigger deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)