### PR TITLE
fix: Make keyboard responsive for narrow viewports

### DIFF
--- a/src/components/Key.scss
+++ b/src/components/Key.scss
@@ -12,6 +12,8 @@
   color: var(--color-text-game);
   background-color: var(--color-key-unused);
   transition: background-color 0.1s ease;
+  flex-shrink: 1;
+  min-width: 0;
 }
 
 .key:hover {
@@ -24,33 +26,39 @@
 
 /* Alphabet keys */
 .key--alphabet {
-  min-width: 43px;
+  flex: 1 1 43px;
+  max-width: 43px;
   font-size: 0.875rem;
 }
 
 .key--alphabet.key--wide {
-  min-width: 65px;
+  flex: 1.5 1 65px;
+  max-width: 65px;
 }
 
 /* Special keys (Delete) */
 .key--special {
-  min-width: 65px;
+  flex: 1.5 1 65px;
+  max-width: 65px;
   font-size: 0.75rem;
 }
 
 .key--special.key--wide {
-  min-width: 85px;
+  flex: 2 1 85px;
+  max-width: 85px;
 }
 
 /* Enter key */
 .key--enter {
-  min-width: 65px;
+  flex: 1.5 1 65px;
+  max-width: 65px;
   font-size: 0.75rem;
   background-color: var(--color-button-shadow);
 }
 
 .key--enter.key--wide {
-  min-width: 85px;
+  flex: 2 1 85px;
+  max-width: 85px;
 }
 
 .key--wrong {

--- a/src/components/Keyboard.scss
+++ b/src/components/Keyboard.scss
@@ -4,10 +4,14 @@
   align-items: center;
   gap: 8px;
   padding: 16px;
+  width: 100%;
+  max-width: 520px;
+  box-sizing: border-box;
 }
 
 .keyboard__row {
   display: flex;
   gap: 6px;
   justify-content: center;
+  width: 100%;
 }


### PR DESCRIPTION
## Summary
- Use flex-based sizing instead of fixed min-width values on keyboard keys
- Keyboard container now has `max-width: 520px` and `width: 100%` to scale down on narrow screens
- Keys shrink proportionally while maintaining their relative sizes

## Test plan
- [x] Tested locally with Playwright at 320px viewport (narrow mobile)
- [x] Tested locally with Playwright at 375px viewport (iPhone)
- [x] Tested at full width viewport - keyboard displays at natural size

🤖 Generated with [Claude Code](https://claude.com/claude-code)