### PR TITLE
feat: Integrate avatar upload with backend API

### DIFF
--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -58,3 +58,38 @@ export const updateUserProfile = async (
 
   return (await response.json()) as UserProfile;
 };
+
+export interface UploadAvatarResponse {
+  avatarUrl: string;
+}
+
+export const uploadAvatar = async (
+  token: string,
+  file: File,
+): Promise<UploadAvatarResponse> => {
+  const MAX_FILE_SIZE: number = 2 * 1024 * 1024; // 2MB
+
+  if (file.size > MAX_FILE_SIZE) {
+    throw new Error('Image must be less than 2MB.');
+  }
+
+  const formData: FormData = new FormData();
+  formData.append('avatar', file);
+
+  const response: Response = await fetch(`${API_BASE_URL}/profile/avatar`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const errorText: string = await response.text();
+    throw new Error(
+      `Failed to upload avatar: ${response.status} - ${errorText}`,
+    );
+  }
+
+  return (await response.json()) as UploadAvatarResponse;
+};

--- a/src/components/features/ProfileForm/ProfileForm.tsx
+++ b/src/components/features/ProfileForm/ProfileForm.tsx
@@ -17,7 +17,11 @@ export interface ProfileFormProps {
   /** Initial profile data */
   initialData: ProfileFormData;
   /** Callback when form is submitted */
-  onSubmit: (data: { displayName: string; avatarUrl: string }) => Promise<void>;
+  onSubmit: (data: {
+    displayName: string;
+    avatarUrl: string;
+    avatarFile?: File;
+  }) => Promise<void>;
   /** Whether profile data is loading */
   isLoading?: boolean;
   /** Whether form is currently saving */
@@ -92,11 +96,10 @@ export const ProfileForm = ({
     }
 
     try {
-      // If there's a pending avatar file, the parent component should handle upload
-      // For now, we just pass the current avatarUrl (which may be a blob URL for preview)
       await onSubmit({
         displayName,
         avatarUrl,
+        avatarFile: pendingAvatarFile ?? undefined,
       });
 
       // Clean up blob URL if we had one

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -7,7 +7,9 @@ import {
 import {
   updateUserProfile,
   getUserProfile,
+  uploadAvatar,
   type UserProfile,
+  type UploadAvatarResponse,
 } from '../api/profile';
 import { Spinner } from '../components/ui/Spinner';
 import { useLocalStorage } from '../hooks/useLocalStorage';
@@ -113,20 +115,33 @@ export const ProfilePage = (): ReactElement => {
   const handleSubmit = async (data: {
     displayName: string;
     avatarUrl: string;
+    avatarFile?: File;
   }): Promise<void> => {
     setIsSaving(true);
     try {
       const token: string = await getAccessTokenSilently();
+
+      let finalAvatarUrl: string = data.avatarUrl;
+
+      // If there's a new avatar file, upload it first
+      if (data.avatarFile) {
+        const uploadResponse: UploadAvatarResponse = await uploadAvatar(
+          token,
+          data.avatarFile,
+        );
+        finalAvatarUrl = uploadResponse.avatarUrl;
+      }
+
       await updateUserProfile(token, {
         displayName: data.displayName,
-        avatarUrl: data.avatarUrl,
+        avatarUrl: finalAvatarUrl,
       });
 
       // Update local profile data to reflect the saved changes
       setProfileData({
         ...profileData,
         displayName: data.displayName,
-        avatarUrl: data.avatarUrl,
+        avatarUrl: finalAvatarUrl,
       });
     } finally {
       setIsSaving(false);


### PR DESCRIPTION
## Summary
- Add `uploadAvatar` function to profile API with 2MB file size validation (client-side check before upload)
- Update ProfileForm to pass avatar file to parent component on submit
- Update ProfilePage to upload avatar to `/profile/avatar` endpoint first, then update profile with the returned URL

## Test plan
- [ ] Navigate to profile page while authenticated
- [ ] Click Edit Profile
- [ ] Upload an avatar image (< 2MB, minimum 500x500 pixels)
- [ ] Save changes
- [ ] Verify avatar is uploaded and displayed correctly
- [ ] Try uploading an image > 2MB and verify rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)