### PR TITLE
fix: Use local date instead of UTC for puzzle date

### DIFF
--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -756,8 +756,12 @@ function convertApiMoveToLocal(move: GradedMove): GradedGuess {
   })) as GradedGuess;
 }
 
-function getTodayIsoDate(): string {
-  return new Date().toISOString().split('T')[0];
+function getTodayLocalDate(): string {
+  const now: Date = new Date();
+  const year: number = now.getFullYear();
+  const month: string = String(now.getMonth() + 1).padStart(2, '0');
+  const day: string = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 function getRandomWord(): string {
@@ -822,7 +826,7 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         guesses: [],
         status: 'playing',
         gameNumber: state.gameNumber + 1,
-        puzzleDate: getTodayIsoDate(),
+        puzzleDate: getTodayLocalDate(),
         isSubmitting: false,
       };
 
@@ -838,7 +842,7 @@ function createInitialState(): GameState {
     guesses: [],
     status: 'playing',
     gameNumber: 1,
-    puzzleDate: getTodayIsoDate(),
+    puzzleDate: getTodayLocalDate(),
     isSubmitting: false,
   };
 }


### PR DESCRIPTION
## Summary
- Fixed `getTodayIsoDate` which used `toISOString()` returning UTC time
- Renamed to `getTodayLocalDate` and now formats local date components directly
- Resolves "No puzzle found for this date" error when user's local time is in a different day than UTC (e.g., late evening in US timezones requesting next day's non-existent puzzle)

## Test plan
- [ ] Verify game works at different times of day, especially late evening in US timezones
- [ ] Confirm puzzle date sent to API matches user's local date

🤖 Generated with [Claude Code](https://claude.com/claude-code)