### PR TITLE
fix: Display server error message in toast

### DIFF
--- a/src/api/guess.ts
+++ b/src/api/guess.ts
@@ -89,7 +89,24 @@ export const submitGuess = async (
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to submit guess: ${response.status}`);
+    let errorMessage: string = `Failed to submit guess: ${response.status}`;
+    try {
+      const errorBody: {
+        error?: { code?: string; message?: string } | string;
+      } = (await response.json()) as {
+        error?: { code?: string; message?: string } | string;
+      };
+      if (errorBody.error) {
+        if (typeof errorBody.error === 'string') {
+          errorMessage = errorBody.error;
+        } else if (errorBody.error.message) {
+          errorMessage = errorBody.error.message;
+        }
+      }
+    } catch {
+      // If we can't parse the response body, use the default message
+    }
+    throw new Error(errorMessage);
   }
 
   return (await response.json()) as GameState;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -13,6 +13,7 @@ export const HomePage = (): ReactElement => {
     status,
     answer,
     invalidWord,
+    error,
     onKeyPress,
     onEnter,
     onBackspace,
@@ -48,7 +49,7 @@ export const HomePage = (): ReactElement => {
       <div className="home-page__game-container">
         <GameBoard guesses={guesses} />
         <Toast
-          message="Not in word list"
+          message={error?.message ?? 'Invalid guess'}
           visible={showToast}
           onHide={hideToast}
         />


### PR DESCRIPTION
## Summary
- Update toast to display the actual error message from the server instead of hardcoded "Not in word list" text
- Server returns errors in `{ error: { code, message } }` format
- Toast now shows messages like "Word not in dictionary", "Game already completed", etc.

## Changes
- `src/api/guess.ts`: Parse nested error object from API response
- `src/pages/HomePage.tsx`: Use `error.message` from `useGame` hook

## Test plan
- [ ] Submit an invalid word (e.g., "ZZZZZ") and verify toast shows "Word not in dictionary"
- [ ] Verify other error scenarios display appropriate server messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)