### PR TITLE
fix: Use namespaced app_metadata key in token

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -27,7 +27,7 @@ export const AppHeader = ({
   )?.user_metadata as Record<string, unknown> | undefined;
   const appMetadata: Record<string, unknown> | undefined = (
     user as Record<string, unknown> | undefined
-  )?.app_metadata as Record<string, unknown> | undefined;
+  )?.['wordles.dev/app_metadata'] as Record<string, unknown> | undefined;
   const avatarSrc: string =
     (userMetadata?.avatar_url as string | undefined) ??
     user?.picture ??

--- a/src/pages/GameMakerPage.tsx
+++ b/src/pages/GameMakerPage.tsx
@@ -34,7 +34,7 @@ export const GameMakerPage = (): ReactElement => {
   // Check if user has game_admin privilege in app_metadata
   const appMetadata: Record<string, unknown> | undefined = (
     user as Record<string, unknown> | undefined
-  )?.app_metadata as Record<string, unknown> | undefined;
+  )?.['wordles.dev/app_metadata'] as Record<string, unknown> | undefined;
   const isGameAdmin: boolean = appMetadata?.game_admin === true;
 
   // Start login flow if not authenticated


### PR DESCRIPTION
## Summary
- Update app_metadata access to use `wordles.dev/app_metadata` namespace for reading admin status from the token

## Test plan
- [ ] Verify admin users can still access Game Maker page
- [ ] Verify non-admin users see 404 on Game Maker page
- [ ] Verify Game Maker menu option shows for admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)