### PR TITLE
fix: Use && in title for Storybook compatibility

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -6,6 +6,6 @@ import { pluginSass } from '@rsbuild/plugin-sass';
 export default defineConfig({
   plugins: [pluginReact(), pluginSass()],
   html: {
-    title: 'wordles <> friends',
+    title: 'wordles && friends',
   },
 });


### PR DESCRIPTION
## Summary
- Change title from `wordles <> friends` to `wordles && friends`
- The `<>` characters were causing HTML parse errors in Storybook build

## Test plan
- [x] Verified `npm run build` passes
- [x] Verified `npm run build-storybook` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)