### PR TITLE
fix: Handle API response shape in getPuzzles

### DIFF
--- a/src/api/puzzle.ts
+++ b/src/api/puzzle.ts
@@ -23,6 +23,10 @@ export interface GetPuzzlesParams {
   endDate?: string;
 }
 
+export interface GetPuzzlesResponse {
+  puzzles: Puzzle[];
+}
+
 export const getPuzzles = async (
   token: string,
   params?: GetPuzzlesParams,
@@ -58,7 +62,26 @@ export const getPuzzles = async (
     throw new Error(`Failed to fetch puzzles: ${response.status}`);
   }
 
-  return (await response.json()) as Puzzle[];
+  const data: unknown = await response.json();
+
+  // Handle expected response shape: { puzzles: [...] }
+  if (
+    data !== null &&
+    typeof data === 'object' &&
+    'puzzles' in data &&
+    Array.isArray((data as GetPuzzlesResponse).puzzles)
+  ) {
+    return (data as GetPuzzlesResponse).puzzles;
+  }
+
+  // Handle case where response is directly an array (backwards compatibility)
+  if (Array.isArray(data)) {
+    return data as Puzzle[];
+  }
+
+  // Response is not in expected format
+  console.error('Unexpected API response format:', data);
+  return [];
 };
 
 export const setPuzzle = async (


### PR DESCRIPTION
## Summary
- Fixes "I.map is not a function" error on gamemaker page
- API returns `{ puzzles: [] }` but code was casting entire response as `Puzzle[]`
- Now correctly extracts the `puzzles` array from response
- Falls back gracefully to empty array if response format is unexpected

## Test plan
- [ ] Navigate to /gamemaker while logged in as admin
- [ ] Verify page loads without crashing when API returns `{ puzzles: [] }`
- [ ] Verify "No puzzles found" message shows for empty results
- [ ] Verify puzzles display correctly when API returns populated data

🤖 Generated with [Claude Code](https://claude.com/claude-code)