### PR TITLE
fix: Correct setPuzzle API endpoint and remove Input hover state

### DIFF
--- a/src/api/puzzle.ts
+++ b/src/api/puzzle.ts
@@ -88,7 +88,7 @@ export const setPuzzle = async (
   token: string,
   data: SetPuzzleRequest,
 ): Promise<SetPuzzleResponse> => {
-  const response: Response = await fetch(`${API_BASE_URL}/puzzle`, {
+  const response: Response = await fetch(`${API_BASE_URL}/puzzles`, {
     method: 'PUT',
     headers: {
       Authorization: `Bearer ${token}`,

--- a/src/components/ui/Input/Input.scss
+++ b/src/components/ui/Input/Input.scss
@@ -23,10 +23,6 @@
       border-color 200ms ease,
       background-color 200ms ease;
 
-    &:hover:not(:disabled) {
-      background: var(--color-button-shadow);
-    }
-
     &:focus {
       border-color: var(--color-button-shadow);
     }


### PR DESCRIPTION
## Summary
- Fix 404 error when submitting puzzles by changing API endpoint from `/puzzle` to `/puzzles`
- Remove green hover background from Input component (date pickers no longer show hover fill)

## Test plan
- [ ] Verify puzzle submission works without 404 error
- [ ] Verify date picker inputs no longer show green hover state

🤖 Generated with [Claude Code](https://claude.com/claude-code)