### PR TITLE
fix: Show 404 page for invalid puzzle date routes

### DIFF
--- a/src/routes/puzzle.tsx
+++ b/src/routes/puzzle.tsx
@@ -1,9 +1,18 @@
-import { createRoute, type AnyRoute } from '@tanstack/react-router';
+import { createRoute, notFound, type AnyRoute } from '@tanstack/react-router';
 import { rootRoute } from './__root';
 import { HomePage } from '../pages/HomePage';
+import { NotFoundPage } from '../pages/NotFoundPage';
+
+const ISO_DATE_REGEX: RegExp = /^\d{4}-\d{2}-\d{2}$/;
 
 export const puzzleRoute: AnyRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/$puzzleDate',
   component: HomePage,
+  notFoundComponent: NotFoundPage,
+  loader: ({ params }) => {
+    if (!ISO_DATE_REGEX.test(params.puzzleDate)) {
+      throw notFound();
+    }
+  },
 });


### PR DESCRIPTION
## Summary
- Routes like `/hello` were incorrectly matching the `/$puzzleDate` route and showing the game board with an invalid date
- Added route-level validation in the `loader` to check if `puzzleDate` matches ISO date format (`YYYY-MM-DD`)
- Invalid routes now properly show the 404 page

## Test plan
- [ ] Navigate to `/hello` → should show 404 page
- [ ] Navigate to `/abc-12-34` → should show 404 page
- [ ] Navigate to `/2026-02-01` → should show game board
- [ ] Navigate to `/profile`, `/history`, `/gamemaker` → should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)