### PR TITLE
feat: Fetch avatar from profile API

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -70,7 +70,7 @@ export interface UserProfile {
 
 export interface UpdateProfileRequest {
   displayName: string;
-  avatarUrl: string;
+  avatarUrl?: string;
 }
 
 export interface UploadAvatarResponse {

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -100,7 +100,6 @@ export const ProfilePage = (): ReactElement => {
 
       await updateUserProfile(token, {
         displayName: data.displayName,
-        avatarUrl: finalAvatarUrl,
       });
 
       // Update local profile data to reflect the saved changes


### PR DESCRIPTION
## Summary
- Fetch avatar URL from `GET /profile` API instead of reading Auth0 `user_metadata` directly
- The backend now returns pre-signed S3 URLs, so the frontend no longer needs direct S3 bucket access
- Make `avatarUrl` optional in `UpdateProfileRequest` — avatar upload endpoint handles storing the key
- Stop sending `avatarUrl` on profile update (the `POST /profile/avatar` endpoint already stores the key in Auth0)

## Depends on
- hannahscovill/scorekeeper#93 (backend pre-signed URL support)

## Test plan
- [x] `npm run build` passes
- [x] Lint, typecheck, prettier all pass
- [ ] Verify avatar displays correctly in header after login
- [ ] Upload new avatar on profile page, verify it displays immediately
- [ ] Verify non-S3 avatars (Gravatar) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)