### PR TITLE
Fix prod: add build-time env vars for PUBLIC_API_URL

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,9 +1,6 @@
 name: Deploy Storybook to GitHub Pages
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,12 @@ jobs:
       - name: Build app
         if: ${{ env.CDK_ACTION != 'destroy' }}
         run: npm run build
+        env:
+          PUBLIC_API_URL: https://api.wordles.dev
+          PUBLIC_AUTH0_DOMAIN: dev-g32naui5mvpwnsg7.us.auth0.com
+          PUBLIC_AUTH0_CLIENT_ID: 4AGUSKMPWgc4jMKUFIJzbS7GBY9IDZob
+          PUBLIC_AUTH0_AUDIENCE: com.hannahscovill.scorekeeper
+          PUBLIC_TURNSTILE_SITE_KEY: 0x4AAAAAACYia9jZUYJ6vUvr
 
       - name: Install CDK dependencies
         working-directory: infra


### PR DESCRIPTION
## Summary
- Add `PUBLIC_API_URL`, `PUBLIC_AUTH0_*`, and `PUBLIC_TURNSTILE_SITE_KEY` env vars to the `npm run build` step in the deploy workflow. Rsbuild inlines `import.meta.env.PUBLIC_*` at build time — without them the production bundle ships with `undefined` values, causing a runtime crash.
- Disable automatic Storybook deploy on push to main (still available via manual dispatch).

## Test plan
- [ ] Merge and verify the deploy workflow passes
- [ ] Confirm wordles.dev loads without `PUBLIC_API_URL is not set` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)