### PR TITLE
Add env var validation and worktree .env auto-copy hook

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,16 @@
+# Auto-copy .env files to new worktrees
+# git worktree add passes: prev_HEAD new_HEAD branch_flag
+# branch_flag=1 for branch checkout, also set for worktree creation
+
+main_worktree="$(git rev-parse --path-format=absolute --git-common-dir)/.."
+
+# Only run when the current directory is NOT the main worktree (i.e. we're in a new worktree)
+current_dir="$(pwd)"
+main_dir="$(cd "$main_worktree" && pwd)"
+
+if [ "$current_dir" != "$main_dir" ] && [ ! -f .env ]; then
+  if [ -f "$main_dir/.env" ]; then
+    cp "$main_dir/.env" .env
+    echo "husky - copied .env from main worktree to $(basename "$current_dir")"
+  fi
+fi

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,6 +50,21 @@ if (!domain || !clientId || !audience) {
   );
 }
 
+const apiUrl: string | undefined = import.meta.env.PUBLIC_API_URL;
+if (!apiUrl) {
+  throw new Error(
+    'PUBLIC_API_URL is not set. Configure it in .env or .env.local.',
+  );
+}
+
+const turnstileSiteKey: string | undefined = import.meta.env
+  .PUBLIC_TURNSTILE_SITE_KEY;
+if (!turnstileSiteKey) {
+  throw new Error(
+    'PUBLIC_TURNSTILE_SITE_KEY is not set. Configure it in .env or .env.local.',
+  );
+}
+
 const posthogKey: string | undefined = import.meta.env.PUBLIC_POSTHOG_KEY;
 if (!posthogKey) {
   throw new Error(


### PR DESCRIPTION
## Summary
- Require `PUBLIC_API_URL` and `PUBLIC_TURNSTILE_SITE_KEY` at startup with fail-fast errors, matching the existing Auth0/PostHog validation pattern
- Add a `.husky/post-checkout` hook that automatically copies `.env` from the main worktree when creating new git worktrees

## Test plan
- [ ] Remove `PUBLIC_TURNSTILE_SITE_KEY` from `.env` and verify the app throws at startup
- [ ] Remove `PUBLIC_API_URL` from `.env` and verify the app throws at startup
- [ ] Run `git worktree add ../test-wt -b test` and verify `.env` is copied automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)