### PR TITLE
Add env var validation and worktree .env auto-copy hook

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,21 @@
+# Auto-setup new worktrees: copy .env and install deps
+# git worktree add passes: prev_HEAD new_HEAD branch_flag
+# branch_flag=1 for branch checkout, also set for worktree creation
+
+main_worktree="$(git rev-parse --path-format=absolute --git-common-dir)/.."
+
+# Only run when the current directory is NOT the main worktree (i.e. we're in a new worktree)
+current_dir="$(pwd)"
+main_dir="$(cd "$main_worktree" && pwd)"
+
+if [ "$current_dir" != "$main_dir" ]; then
+  if [ ! -f .env ] && [ -f "$main_dir/.env" ]; then
+    cp "$main_dir/.env" .env
+    echo "husky - copied .env from main worktree to $(basename "$current_dir")"
+  fi
+
+  if [ ! -d node_modules ]; then
+    echo "husky - installing dependencies in $(basename "$current_dir")..."
+    npm install
+  fi
+fi


### PR DESCRIPTION
## Summary
- Adds fail-fast startup validation for `PUBLIC_API_URL`, `PUBLIC_TURNSTILE_SITE_KEY`, and `PUBLIC_POSTHOG_KEY` in `index.tsx` (matching the existing Auth0 pattern)
- Adds `.husky/post-checkout` hook that auto-copies `.env` from the main worktree when creating new git worktrees

## Test plan
- [x] Verified locally that missing env vars cause a clear error on startup
- [x] Verified the post-checkout hook copies `.env` to new worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)