### PR TITLE
Add Secrets Manager permission for frontend build config

### DIFF
--- a/infra/lib/github-actions-role-stack.ts
+++ b/infra/lib/github-actions-role-stack.ts
@@ -264,6 +264,18 @@ export class GitHubActionsRoleStack extends cdk.Stack {
       }),
     );
 
+    // Secrets Manager - frontend build config (wordles/frontend/*)
+    role.addToPolicy(
+      new iam.PolicyStatement({
+        sid: 'SecretsManagerFrontend',
+        effect: iam.Effect.ALLOW,
+        actions: ['secretsmanager:GetSecretValue'],
+        resources: [
+          `arn:aws:secretsmanager:us-west-2:${this.account}:secret:wordles/frontend/*`,
+        ],
+      }),
+    );
+
     // Lambda permissions for CDK BucketDeployment custom resource
     role.addToPolicy(
       new iam.PolicyStatement({


### PR DESCRIPTION
## Summary
- Grants the GitHub Actions IAM role `secretsmanager:GetSecretValue` access to `wordles/frontend/*` secrets
- Enables CI/CD pipelines to read frontend build configuration from Secrets Manager

## Test plan
- [x] Verify CDK synth succeeds with the updated stack
- [x] Deploy and confirm GHA workflows can read frontend secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)