### PR TITLE
Remove unused docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-services:
-  web:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    ports:
-      - '3000:3000'
-    env_file:
-      - .env


### PR DESCRIPTION
## Summary
- Deletes the unused `docker-compose.yml` (simple dev Dockerfile wrapper)
- The app runs directly via npm scripts; production deploys via CDK

## Test plan
- [x] Pre-commit hooks pass (lint, typecheck, prettier, tests)
- [ ] Verify no workflows or scripts reference this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)