### PR TITLE
Send environment metadata and PostHog session ID with issue reports

### DIFF
--- a/src/api/issues.ts
+++ b/src/api/issues.ts
@@ -13,6 +13,9 @@ export interface IssueReport {
   website?: string;
   userAgent?: string;
   pageUrl?: string;
+  posthogSessionId?: string;
+  clientEnvironmentName?: string;
+  clientCommitHash?: string;
 }
 
 export interface IssueReportResponse {

--- a/src/components/IssueReportModal/IssueReportModal.tsx
+++ b/src/components/IssueReportModal/IssueReportModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, type ReactElement, type FormEvent } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
+import posthog from 'posthog-js';
 import { Modal, Button, Input, Textarea, Spinner } from '../ui';
 import { Turnstile } from '../Turnstile';
 import { submitIssueReport, type IssueReportResponse } from '../../api/issues';
@@ -116,6 +117,9 @@ export const IssueReportModal = ({
           website,
           userAgent: navigator.userAgent,
           pageUrl: window.location.href,
+          posthogSessionId: posthog.get_session_id(),
+          clientEnvironmentName: import.meta.env.PUBLIC_ENVIRONMENT_NAME,
+          clientCommitHash: import.meta.env.PUBLIC_COMMIT_HASH,
         },
         token,
       );


### PR DESCRIPTION
## Summary
- Added `posthogSessionId`, `clientEnvironmentName`, and `clientCommitHash` to the `IssueReport` interface
- `IssueReportModal` now captures PostHog session ID via `posthog.get_session_id()`, environment name from `PUBLIC_ENVIRONMENT_NAME`, and commit hash from `PUBLIC_COMMIT_HASH`

## Test plan
- [x] TypeScript type-check passes
- [x] Lint, format, and test suite all pass (pre-commit hook)
- [x] Docker compose stack builds and runs (`FE_DIR=fe/issue-report-metadata-fe`)
- [ ] Submit an issue via the frontend and verify the new metadata appears in the GitHub issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)