### PR TITLE
Copy Claude settings into new worktrees during post-checkout

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -14,6 +14,12 @@ if [ "$current_dir" != "$main_dir" ]; then
     echo "husky - copied .env from main worktree to $(basename "$current_dir")"
   fi
 
+  if [ -f "$main_dir/.claude/settings.local.json" ]; then
+    mkdir -p .claude
+    cp "$main_dir/.claude/settings.local.json" .claude/settings.local.json
+    echo "husky - copied .claude/settings.local.json from main worktree to $(basename "$current_dir")"
+  fi
+
   if [ ! -d node_modules ]; then
     echo "husky - installing dependencies in $(basename "$current_dir")..."
     npm install


### PR DESCRIPTION
## Summary
- The post-checkout hook now copies `.claude/settings.local.json` from the main worktree into new worktrees alongside `.env`

## Test plan
- [x] Pre-commit hook passes (lint, typecheck, format, tests)
- [ ] Create a new worktree and verify `.claude/settings.local.json` is copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)