### PR TITLE
Switch to drivewire Auth0 tenant (tenant-scoped secrets)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,9 +12,9 @@
 #
 # Required AWS Secrets Manager secrets (us-west-2):
 # ---------------------------------------------------------------------------------
-# wordles/frontend/auth0        → { domain, clientId, audience }
-# wordles/frontend/api-url      → { api-base-url, otel-collector-url }
-# wordles/frontend/posthog      → { key, host }
+# wordles/frontend/<tenant>/auth0     → { domain, clientId, audience }
+# wordles/frontend/api-url            → { api-base-url, otel-collector-url }
+# wordles/frontend/posthog            → { key, host }
 # wordles/frontend/turnstile-site-key → { site-key }
 #
 # AWS OIDC Setup:
@@ -75,6 +75,7 @@ concurrency:
 
 env:
   AWS_REGION: ${{ secrets.AWS_REGION }}
+  AUTH0_TENANT: drivewire
 
 jobs:
   deploy:
@@ -110,7 +111,7 @@ jobs:
           sm() { aws secretsmanager get-secret-value --secret-id "$1" --query SecretString --output text; }
           field() { echo "$1" | python3 -c "import sys,json; print(json.load(sys.stdin)['$2'])"; }
 
-          AUTH0=$(sm wordles/frontend/auth0)
+          AUTH0=$(sm wordles/frontend/${{ env.AUTH0_TENANT }}/auth0)
           echo "PUBLIC_AUTH0_DOMAIN=$(field "$AUTH0" domain)" >> "$GITHUB_ENV"
           echo "PUBLIC_AUTH0_CLIENT_ID=$(field "$AUTH0" clientId)" >> "$GITHUB_ENV"
           echo "PUBLIC_AUTH0_AUDIENCE=$(field "$AUTH0" audience)" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- Add `AUTH0_TENANT: drivewire` env var to deploy workflow
- Scope auth0 secret path to `wordles/frontend/<tenant>/auth0`
- Non-auth0 secrets (`api-url`, `posthog`, `turnstile-site-key`) unchanged

## Prerequisite
Ensure `wordles/frontend/drivewire/auth0` exists in AWS Secrets Manager with fields: `domain`, `clientId`, `audience`

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] FE pre-commit hooks pass (lint, typecheck, format, tests — 6/6)
- [x] Local QA via `compose.sh` with worktree — frontend starts, auth works
- [ ] Verify deploy workflow with `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)