### PR TITLE
Fix: Guard submitGuess against double-submission (#118)

### DIFF
--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -81,7 +81,11 @@ function gameReducer(state: GameState, action: GameAction): GameState {
       };
 
     case 'SUBMIT_GUESS_START':
-      if (state.status !== 'playing' || state.currentGuess.length !== 5) {
+      if (
+        state.status !== 'playing' ||
+        state.currentGuess.length !== 5 ||
+        state.isSubmitting
+      ) {
         return state;
       }
       return {
@@ -304,7 +308,11 @@ export function useGame(options: UseGameOptions = {}): UseGameReturn {
 
   const submitGuess: () => Promise<void> =
     useCallback(async (): Promise<void> => {
-      if (state.status !== 'playing' || state.currentGuess.length !== 5) {
+      if (
+        state.status !== 'playing' ||
+        state.currentGuess.length !== 5 ||
+        state.isSubmitting
+      ) {
         return;
       }
 
@@ -353,6 +361,7 @@ export function useGame(options: UseGameOptions = {}): UseGameReturn {
       state.status,
       state.currentGuess,
       state.puzzleDate,
+      state.isSubmitting,
       isAuthenticated,
       getAccessTokenSilently,
     ]);


### PR DESCRIPTION
## Summary
- Adds `state.isSubmitting` guard to the `submitGuess` callback early-return check, preventing duplicate API calls during network latency
- Adds `state.isSubmitting` guard to the reducer's `SUBMIT_GUESS_START` case for defense-in-depth
- Adds `state.isSubmitting` to the `useCallback` dependency array so the closure captures the fresh value

## Test plan
- [x] Pre-commit hooks pass (ESLint, TypeScript, Prettier, unit tests)
- [ ] Run `compose.sh up --build` and test in browser: rapid Enter presses should only record the guess once
- [ ] Verify the submit button / keyboard is properly disabled during submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)