### PR TITLE
Replace Share text button with platform-native icon in history

### DIFF
--- a/src/pages/ScoreHistoryPage.scss
+++ b/src/pages/ScoreHistoryPage.scss
@@ -52,7 +52,6 @@
 
   &__date-cell {
     font-weight: 600;
-    white-space: nowrap;
     vertical-align: middle;
   }
 
@@ -65,14 +64,6 @@
     }
   }
 
-  &__completed {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-  }
-
   &__today-button {
     .button__frame {
       background-color: var(--color-button-shadow);
@@ -81,6 +72,22 @@
 
   &__game-cell {
     vertical-align: middle;
+  }
+
+  &__share-icon {
+    display: block;
+    margin: 16px auto 0;
+    padding: 6px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--color-text);
+    opacity: 0.5;
+    transition: opacity 200ms ease;
+
+    &:hover {
+      opacity: 1;
+    }
   }
 
   &__in-progress {

--- a/src/pages/ScoreHistoryPage.tsx
+++ b/src/pages/ScoreHistoryPage.tsx
@@ -33,6 +33,10 @@ import {
 import { generateShareText, shareResult } from '../utils/share';
 import './ScoreHistoryPage.scss';
 
+const isApplePlatform: boolean =
+  typeof navigator !== 'undefined' &&
+  /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+
 export const ScoreHistoryPage = (): ReactElement => {
   // Router protects this route - we trust we're authenticated if rendering
   const { getAccessTokenSilently } = useAuth0();
@@ -267,15 +271,62 @@ export const ScoreHistoryPage = (): ReactElement => {
                   >
                     {formatDateForDisplay(entry.puzzle_date)}
                   </Link>
+                  {entry.played && entry.guesses && (
+                    <button
+                      type="button"
+                      className="score-history-page__share-icon"
+                      onClick={() => handleShare(entry)}
+                      aria-label={`Share result for ${formatDateForDisplay(entry.puzzle_date)}`}
+                    >
+                      {isApplePlatform ? (
+                        <svg
+                          width="18"
+                          height="18"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+                          <polyline points="16 6 12 2 8 6" />
+                          <line x1="12" y1="2" x2="12" y2="15" />
+                        </svg>
+                      ) : (
+                        <svg
+                          width="18"
+                          height="18"
+                          viewBox="0 0 24 24"
+                          fill="currentColor"
+                        >
+                          <circle cx="18" cy="5" r="3" />
+                          <circle cx="6" cy="12" r="3" />
+                          <circle cx="18" cy="19" r="3" />
+                          <line
+                            x1="8.59"
+                            y1="13.51"
+                            x2="15.42"
+                            y2="17.49"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                          />
+                          <line
+                            x1="15.41"
+                            y1="6.51"
+                            x2="8.59"
+                            y2="10.49"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                          />
+                        </svg>
+                      )}
+                    </button>
+                  )}
                 </td>
                 <td className="score-history-page__game-cell">
                   {entry.played && entry.guesses ? (
-                    <div className="score-history-page__completed">
-                      <MiniGameBoard guesses={entry.guesses} />
-                      <Button variant="flat" onClick={() => handleShare(entry)}>
-                        Share
-                      </Button>
-                    </div>
+                    <MiniGameBoard guesses={entry.guesses} />
                   ) : entry.in_progress && entry.guesses ? (
                     <div className="score-history-page__in-progress">
                       <MiniGameBoard guesses={entry.guesses} />


### PR DESCRIPTION
## Summary
- Move share action from Game column to Date column as a subtle platform-native icon below the date text
- Game column now only shows boards or Play/Continue buttons, making played vs unplayed status immediately scannable
- Share icon adapts per platform: iOS-style (box with arrow) on Apple devices, Android-style (connected dots) elsewhere
- Remove `white-space: nowrap` on date cells to prevent horizontal overflow on narrow viewports (fixes mobile scrolling)

## Test plan
- [ ] Verify share icon appears below date on completed game rows
- [ ] Verify no share icon on unplayed/in-progress rows
- [ ] Verify clicking the share icon still copies/shares the game result
- [ ] Verify Play/Continue buttons are centered in the Game column
- [ ] Test on mobile viewport (320px+) — no horizontal scroll
- [ ] Test with Chrome DevTools Android user agent — should show connected-dots icon
- [ ] Test on macOS/iOS — should show box-with-arrow icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)