### PR TITLE
Extract ShareIconButton and use in game modal

### DIFF
--- a/src/components/GameStatusModal.tsx
+++ b/src/components/GameStatusModal.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, type ReactElement } from 'react';
 import { useNavigate, type NavigateFn } from '@tanstack/react-router';
 import type { GuessLetterProps } from './GuessLetter';
 import type { LetterGrade } from '../api/types';
+import { ShareIconButton } from './ShareIconButton';
 import { Toast } from './Toast';
 import { Button, Modal } from './ui';
 import { generateShareText, shareResult } from '../utils/share';
@@ -58,9 +59,10 @@ export const GameStatusModal = ({
       <p className="game-status-modal__message">
         {won ? 'You won!' : answer ? `The word was: ${answer}` : 'Game over'}
       </p>
-      <Button size="s" variant="onLight" onClick={handleShare}>
-        Share
-      </Button>
+      <ShareIconButton
+        onClick={handleShare}
+        aria-label={`Share result for ${puzzleDate}`}
+      />
       <Button size="s" variant="onLight" onClick={handlePlayOtherGames}>
         Play Other Games
       </Button>

--- a/src/components/ShareIconButton.scss
+++ b/src/components/ShareIconButton.scss
@@ -1,0 +1,14 @@
+.share-icon-button {
+  display: block;
+  padding: 6px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--color-text);
+  opacity: 0.5;
+  transition: opacity 200ms ease;
+
+  &:hover {
+    opacity: 1;
+  }
+}

--- a/src/components/ShareIconButton.tsx
+++ b/src/components/ShareIconButton.tsx
@@ -1,0 +1,62 @@
+import type { ReactElement } from 'react';
+import './ShareIconButton.scss';
+
+const isApplePlatform: boolean =
+  typeof navigator !== 'undefined' &&
+  /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+
+export interface ShareIconButtonProps {
+  onClick: () => void;
+  'aria-label': string;
+}
+
+export const ShareIconButton = ({
+  onClick,
+  'aria-label': ariaLabel,
+}: ShareIconButtonProps): ReactElement => (
+  <button
+    type="button"
+    className="share-icon-button"
+    onClick={onClick}
+    aria-label={ariaLabel}
+  >
+    {isApplePlatform ? (
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+        <polyline points="16 6 12 2 8 6" />
+        <line x1="12" y1="2" x2="12" y2="15" />
+      </svg>
+    ) : (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+        <circle cx="18" cy="5" r="3" />
+        <circle cx="6" cy="12" r="3" />
+        <circle cx="18" cy="19" r="3" />
+        <line
+          x1="8.59"
+          y1="13.51"
+          x2="15.42"
+          y2="17.49"
+          stroke="currentColor"
+          strokeWidth="2"
+        />
+        <line
+          x1="15.41"
+          y1="6.51"
+          x2="8.59"
+          y2="10.49"
+          stroke="currentColor"
+          strokeWidth="2"
+        />
+      </svg>
+    )}
+  </button>
+);

--- a/src/pages/ScoreHistoryPage.scss
+++ b/src/pages/ScoreHistoryPage.scss
@@ -74,20 +74,8 @@
     vertical-align: middle;
   }
 
-  &__share-icon {
-    display: block;
+  &__date-cell .share-icon-button {
     margin: 16px auto 0;
-    padding: 6px;
-    border: none;
-    background: none;
-    cursor: pointer;
-    color: var(--color-text);
-    opacity: 0.5;
-    transition: opacity 200ms ease;
-
-    &:hover {
-      opacity: 1;
-    }
   }
 
   &__in-progress {

--- a/src/pages/ScoreHistoryPage.tsx
+++ b/src/pages/ScoreHistoryPage.tsx
@@ -18,6 +18,7 @@ import {
   type Puzzle,
 } from '../api';
 import { MiniGameBoard } from '../components/MiniGameBoard';
+import { ShareIconButton } from '../components/ShareIconButton';
 import { Toast } from '../components/Toast';
 import { Button } from '../components/ui/Button';
 import { Spinner } from '../components/ui/Spinner';
@@ -32,10 +33,6 @@ import {
 } from '../utils/dates';
 import { generateShareText, shareResult } from '../utils/share';
 import './ScoreHistoryPage.scss';
-
-const isApplePlatform: boolean =
-  typeof navigator !== 'undefined' &&
-  /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
 export const ScoreHistoryPage = (): ReactElement => {
   // Router protects this route - we trust we're authenticated if rendering
@@ -272,56 +269,10 @@ export const ScoreHistoryPage = (): ReactElement => {
                     {formatDateForDisplay(entry.puzzle_date)}
                   </Link>
                   {entry.played && entry.guesses && (
-                    <button
-                      type="button"
-                      className="score-history-page__share-icon"
+                    <ShareIconButton
                       onClick={() => handleShare(entry)}
                       aria-label={`Share result for ${formatDateForDisplay(entry.puzzle_date)}`}
-                    >
-                      {isApplePlatform ? (
-                        <svg
-                          width="18"
-                          height="18"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2.5"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        >
-                          <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
-                          <polyline points="16 6 12 2 8 6" />
-                          <line x1="12" y1="2" x2="12" y2="15" />
-                        </svg>
-                      ) : (
-                        <svg
-                          width="18"
-                          height="18"
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                        >
-                          <circle cx="18" cy="5" r="3" />
-                          <circle cx="6" cy="12" r="3" />
-                          <circle cx="18" cy="19" r="3" />
-                          <line
-                            x1="8.59"
-                            y1="13.51"
-                            x2="15.42"
-                            y2="17.49"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                          />
-                          <line
-                            x1="15.41"
-                            y1="6.51"
-                            x2="8.59"
-                            y2="10.49"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                          />
-                        </svg>
-                      )}
-                    </button>
+                    />
                   )}
                 </td>
                 <td className="score-history-page__game-cell">


### PR DESCRIPTION
## Summary
- Extracted the platform-native share icon (Apple upload arrow / Android share nodes) from `ScoreHistoryPage` into a reusable `ShareIconButton` component
- Replaced the text "Share" `<Button>` in `GameStatusModal` with the new `ShareIconButton`, so both the game completion modal and score history use the same icon
- Moved base icon styles (padding, opacity, hover transition) into `ShareIconButton.scss`; history page retains only the positioning override (`margin: 16px auto 0`)

## Test plan
- [ ] Complete a game and verify the modal shows the platform-native share icon instead of the old text button
- [ ] Click the share icon in the modal — on mobile it should open the native share sheet; on desktop it should copy to clipboard and show the toast
- [ ] Visit the history page and verify the share icons still appear and work identically to before
- [ ] Test on both Apple (Mac/iOS) and non-Apple platforms to confirm correct icon variant renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)