### PR TITLE
Add Teams page behind PostHog feature flag

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -5,6 +5,7 @@ import {
   useNavigate,
   type UseNavigateResult,
 } from '@tanstack/react-router';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { AvatarMenu } from './AvatarMenu';
 import { IssueReportModal } from './IssueReportModal';
 import { useLocalStorage } from '../hooks/useLocalStorage';
@@ -46,6 +47,7 @@ export const AppHeader = ({
     profile?.avatarUrl ?? 'https://www.gravatar.com/avatar/?d=mp';
   const avatarAlt: string = user?.email ?? user?.name ?? 'User avatar';
   const isGameAdmin: boolean = appMetadata?.game_admin === true;
+  const showTeams: boolean = useFeatureFlagEnabled('teams') === true;
 
   return (
     <>
@@ -59,8 +61,10 @@ export const AppHeader = ({
             avatarAlt={avatarAlt}
             isLoggedIn={isLoggedIn}
             isGameAdmin={isGameAdmin}
+            showTeams={showTeams}
             onLogInClick={() => loginWithRedirect()}
             onProfileClick={() => navigate({ to: '/profile' })}
+            onTeamsClick={() => navigate({ to: '/teams' })}
             onScoreHistoryClick={() => navigate({ to: '/history' })}
             onGameMakerClick={() => navigate({ to: '/gamemaker' })}
             onLogOutClick={() =>

--- a/src/components/AvatarMenu.tsx
+++ b/src/components/AvatarMenu.tsx
@@ -12,10 +12,14 @@ export interface AvatarMenuProps {
   isLoggedIn?: boolean;
   /** Whether the user is a game admin */
   isGameAdmin?: boolean;
+  /** Whether to show the Teams option */
+  showTeams?: boolean;
   /** Handler for log in option click */
   onLogInClick?: () => void;
   /** Handler for profile option click */
   onProfileClick?: () => void;
+  /** Handler for teams option click */
+  onTeamsClick?: () => void;
   /** Handler for score history option click */
   onScoreHistoryClick?: () => void;
   /** Handler for game maker option click */
@@ -31,8 +35,10 @@ export const AvatarMenu = ({
   avatarAlt = 'User avatar',
   isLoggedIn = false,
   isGameAdmin = false,
+  showTeams = false,
   onLogInClick,
   onProfileClick,
+  onTeamsClick,
   onScoreHistoryClick,
   onGameMakerClick,
   onLogOutClick,
@@ -97,6 +103,18 @@ export const AvatarMenu = ({
                 Profile
               </button>
             </li>
+            {showTeams && (
+              <li role="none">
+                <button
+                  type="button"
+                  className="avatar-menu__item"
+                  role="menuitem"
+                  onClick={onTeamsClick}
+                >
+                  Teams
+                </button>
+              </li>
+            )}
             {isGameAdmin && (
               <li role="none">
                 <button

--- a/src/data/teamsHardcodedSample.json
+++ b/src/data/teamsHardcodedSample.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "7FED4D33-903F-41B5-AF8F-ABE45CFEEB0C",
+    "name": "VROOM",
+    "avatarUrl": "https://static.vecteezy.com/system/resources/previews/055/196/367/non_2x/editable-motorbike-linear-icon-thin-line-illustration-motorcycle-contour-symbol-isolated-outline-drawing-editable-stroke-vector.jpg"
+  },
+  {
+    "id": "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+    "name": "Ninja Turtles",
+    "avatarUrl": "https://static.vecteezy.com/system/resources/previews/024/044/268/non_2x/ninja-icon-clipart-transparent-free-png.png"
+  },
+  {
+    "id": "B2C3D4E5-F6A7-8901-BCDE-F12345678901",
+    "name": "Wordle as a Service",
+    "avatarUrl": "https://static.vecteezy.com/system/resources/previews/012/872/334/non_2x/cloud-computing-line-icon-illustration-vector.jpg"
+  }
+]

--- a/src/pages/TeamsPage.scss
+++ b/src/pages/TeamsPage.scss
@@ -1,0 +1,42 @@
+.teams-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 800px;
+  margin: 0 auto;
+
+  &__title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-bottom: 24px;
+    color: var(--color-text-primary, #1a1a1b);
+  }
+
+  &__table {
+    width: 100%;
+    border-collapse: collapse;
+
+    td {
+      padding: 12px 16px;
+    }
+
+    tbody tr {
+      border-bottom: 3px solid #000;
+
+      &:first-child {
+        border-top: 3px solid #000;
+      }
+    }
+  }
+
+  &__avatar-cell {
+    width: 48px;
+    line-height: 0;
+  }
+
+  &__name-cell {
+    font-weight: 600;
+    font-size: 1rem;
+    text-align: center;
+  }
+}

--- a/src/pages/TeamsPage.tsx
+++ b/src/pages/TeamsPage.tsx
@@ -1,0 +1,41 @@
+import type { ReactElement } from 'react';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
+import { Avatar } from '../components/ui/Avatar';
+import { NotFoundPage } from './NotFoundPage';
+import teams from '../data/teamsHardcodedSample.json';
+import './TeamsPage.scss';
+
+interface Team {
+  id: string;
+  name: string;
+  avatarUrl: string;
+}
+
+export const TeamsPage = (): ReactElement => {
+  const teamsEnabled: boolean | undefined = useFeatureFlagEnabled('teams');
+
+  if (teamsEnabled !== true) {
+    return <NotFoundPage />;
+  }
+
+  const teamList: Team[] = teams as Team[];
+
+  return (
+    <div className="teams-page">
+      <h2 className="teams-page__title">Teams</h2>
+
+      <table className="teams-page__table">
+        <tbody>
+          {teamList.map((team) => (
+            <tr key={team.id}>
+              <td className="teams-page__avatar-cell">
+                <Avatar src={team.avatarUrl} alt={team.name} size="s" />
+              </td>
+              <td className="teams-page__name-cell">{team.name}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,10 +9,12 @@ import { profileRoute } from './routes/profile';
 import { historyRoute } from './routes/history';
 import { puzzleRoute } from './routes/puzzle';
 import { gamemakerRoute } from './routes/gamemaker';
+import { teamsRoute } from './routes/teams';
 
 const routeTree: AnyRoute = rootRoute.addChildren([
   indexRoute,
   profileRoute,
+  teamsRoute,
   historyRoute,
   puzzleRoute,
   gamemakerRoute,

--- a/src/routes/teams.tsx
+++ b/src/routes/teams.tsx
@@ -1,0 +1,9 @@
+import { createRoute, type AnyRoute } from '@tanstack/react-router';
+import { rootRoute } from './__root';
+import { TeamsPage } from '../pages/TeamsPage';
+
+export const teamsRoute: AnyRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/teams',
+  component: TeamsPage,
+});


### PR DESCRIPTION
## Summary
- Adds a new `/teams` route displaying a table of teams (avatar + name per row)
- Adds a "Teams" menu item in the avatar menu, positioned after "Profile" (logged-in users only)
- Both the route and menu item are gated behind the PostHog `teams` feature flag — when the flag is off, the route shows a 404 and the menu item is hidden
- Includes hardcoded sample data with 3 teams: VROOM, Ninja Turtles, Wordle as a Service

## Test plan
- [ ] Enable `teams` feature flag in PostHog, log in, and verify "Teams" appears in the avatar menu
- [ ] Click "Teams" and verify navigation to `/teams` with all 3 team entries visible
- [ ] Disable the `teams` feature flag and verify the menu item disappears and `/teams` shows a 404
- [ ] Verify logged-out users do not see the "Teams" menu item regardless of flag state

🤖 Generated with [Claude Code](https://claude.com/claude-code)