### PR TITLE
Fix mobile signup opt-in copy and stale What's New badge

### DIFF
--- a/src/components/MobileAppSignup.tsx
+++ b/src/components/MobileAppSignup.tsx
@@ -82,9 +82,20 @@ export const MobileAppSignup = ({
   onSuccess,
 }: MobileAppSignupProps): ReactElement => {
   const { isAuthenticated, getAccessTokenSilently, user } = useAuth0();
-  const userMetadata: Record<string, unknown> | undefined = (
-    user as Record<string, unknown> | undefined
-  )?.['user_metadata'] as Record<string, unknown> | undefined;
+  const userRecord: Record<string, unknown> | undefined = user as
+    | Record<string, unknown>
+    | undefined;
+  // Auth0 (OIDC-conformant) strips unnamespaced custom claims from the ID
+  // token, so prefer the namespaced claim (matches wordles.dev/app_metadata
+  // used elsewhere), falling back to the bare key in case the token isn't
+  // namespaced in this tenant.
+  const userMetadata: Record<string, unknown> | undefined =
+    (userRecord?.['wordles.dev/user_metadata'] as
+      | Record<string, unknown>
+      | undefined) ??
+    (userRecord?.['user_metadata'] as Record<string, unknown> | undefined);
+  // TEMP DEBUG: remove once the id token claim shape is confirmed in prod
+  console.debug('[MobileAppSignup] id token user claims', user);
   const hasOptedIntoBothPlatforms: boolean =
     userMetadata?.mobile_test_track_opt_in_ios === true &&
     userMetadata?.mobile_test_track_opt_in_android === true;

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,6 +1,8 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 
 type SetValue<T> = (value: T | null) => void;
+
+const eventName = (key: string): string => `local-storage:${key}`;
 
 export const useLocalStorage = <T>(
   key: string,
@@ -15,6 +17,22 @@ export const useLocalStorage = <T>(
     }
   });
 
+  // Other useLocalStorage instances for this key (e.g. the header badge vs.
+  // the page that clears it) live in separate components and don't remount
+  // on client-side navigation, so they need to be told a write happened.
+  useEffect(() => {
+    const handleChange = (): void => {
+      try {
+        const item: string | null = localStorage.getItem(key);
+        setStoredValue(item !== null ? (JSON.parse(item) as T) : initialValue);
+      } catch {
+        setStoredValue(initialValue);
+      }
+    };
+    window.addEventListener(eventName(key), handleChange);
+    return (): void => window.removeEventListener(eventName(key), handleChange);
+  }, [key, initialValue]);
+
   const setValue: SetValue<T> = useCallback(
     (value: T | null): void => {
       try {
@@ -24,6 +42,7 @@ export const useLocalStorage = <T>(
         } else {
           localStorage.setItem(key, JSON.stringify(value));
         }
+        window.dispatchEvent(new Event(eventName(key)));
       } catch (error) {
         console.error(`Error setting localStorage key "${key}":`, error);
       }


### PR DESCRIPTION
## Summary
- The "opted into both test tracks" check in `MobileAppSignup` was reading a bare `user_metadata` claim off the ID token, which Auth0 (OIDC-conformant) strips unless the claim is namespaced. Check `wordles.dev/user_metadata` first, matching the `wordles.dev/app_metadata` convention already proven to work in `AppHeader`/`GameMakerPage`, falling back to the bare key. Adds a temporary `console.debug` of the raw user claims so we can confirm the actual shape against a real "opted into both" session before removing it.
- The "What's New" unread badge in the header didn't clear after visiting `/whats-new` without a full page refresh. `AppHeader` and `WhatsNewPage` each hold independent `useLocalStorage` instances for the same key; `AppHeader` stays mounted across client-side navigation, so it never re-read the value `WhatsNewPage` wrote. `useLocalStorage` now broadcasts a same-tab `window` event on write so other instances watching the same key re-sync.

## Test plan
- [x] `tsc --noEmit`, `lint`, `test` all pass
- [ ] Reload the deployed app as a user with both `mobile_test_track_opt_in_ios`/`android` set, confirm the "You've requested to join both internal test tracks..." copy renders and check the console.debug output to verify the real claim path, then remove the debug log
- [ ] Confirm the header badge clears immediately after visiting `/whats-new` via in-app navigation (no refresh needed)

Follow-up to #143.